### PR TITLE
Fix jittery hero badge float animation

### DIFF
--- a/site/src/index.html
+++ b/site/src/index.html
@@ -42,7 +42,12 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <img src="./images/badge_gitHub.svg" alt="GitHub" />
+              <img
+                src="./images/badge_gitHub.svg"
+                alt="GitHub"
+                width="110"
+                height="28"
+              />
             </a>
             <a
               href="http://gitlab.com/JonoAugustine"
@@ -50,7 +55,12 @@
               rel="noopener noreferrer"
               class="badge"
             >
-              <img src="./images/badge_gitLab.svg" alt="GitLab" />
+              <img
+                src="./images/badge_gitLab.svg"
+                alt="GitLab"
+                width="108"
+                height="28"
+              />
             </a>
             <a
               href="http://www.linkedin.com/in/jonathan-augustine-14678b124/"
@@ -58,7 +68,12 @@
               rel="noopener noreferrer"
               class="badge"
             >
-              <img src="./images/badge_linkedin.svg" alt="LinkedIn" />
+              <img
+                src="./images/badge_linkedin.svg"
+                alt="LinkedIn"
+                width="125"
+                height="28"
+              />
             </a>
             <a
               href="./images/JonoAugustineResume.pdf"
@@ -66,7 +81,12 @@
               rel="noopener noreferrer"
               class="badge"
             >
-              <img src="./images/badge_resume.svg" alt="Resume" />
+              <img
+                src="./images/badge_resume.svg"
+                alt="Resume"
+                width="97"
+                height="28"
+              />
             </a>
           </div>
           <button id="header_scroll" class="scroller">My Projects</button>

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -35,60 +35,6 @@
             <h1 class="brand">Jono Augustine</h1>
             <h3 class="tagline">Creating solutions to unsolved problems</h3>
           </section>
-          <div id="badges" class="container fluid row">
-            <a
-              class="badge"
-              href="https://github.com/JonoAugustine"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <img
-                src="./images/badge_gitHub.svg"
-                alt="GitHub"
-                width="110"
-                height="28"
-              />
-            </a>
-            <a
-              href="http://gitlab.com/JonoAugustine"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="badge"
-            >
-              <img
-                src="./images/badge_gitLab.svg"
-                alt="GitLab"
-                width="108"
-                height="28"
-              />
-            </a>
-            <a
-              href="http://www.linkedin.com/in/jonathan-augustine-14678b124/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="badge"
-            >
-              <img
-                src="./images/badge_linkedin.svg"
-                alt="LinkedIn"
-                width="125"
-                height="28"
-              />
-            </a>
-            <a
-              href="./images/JonoAugustineResume.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="badge"
-            >
-              <img
-                src="./images/badge_resume.svg"
-                alt="Resume"
-                width="97"
-                height="28"
-              />
-            </a>
-          </div>
           <button id="header_scroll" class="scroller">My Projects</button>
           <span class="konami">(try konami)</span>
         </div>
@@ -99,6 +45,61 @@
           <h4>me@JonoAugustine.com</h4>
         </div>
       </nav>
+
+      <div id="badges" class="container center fluid row">
+        <a
+          class="badge"
+          href="https://github.com/JonoAugustine"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="./images/badge_gitHub.svg"
+            alt="GitHub"
+            width="110"
+            height="28"
+          />
+        </a>
+        <a
+          href="http://gitlab.com/JonoAugustine"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="badge"
+        >
+          <img
+            src="./images/badge_gitLab.svg"
+            alt="GitLab"
+            width="108"
+            height="28"
+          />
+        </a>
+        <a
+          href="http://www.linkedin.com/in/jonathan-augustine-14678b124/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="badge"
+        >
+          <img
+            src="./images/badge_linkedin.svg"
+            alt="LinkedIn"
+            width="125"
+            height="28"
+          />
+        </a>
+        <a
+          href="./images/JonoAugustineResume.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="badge"
+        >
+          <img
+            src="./images/badge_resume.svg"
+            alt="Resume"
+            width="97"
+            height="28"
+          />
+        </a>
+      </div>
 
       <div class="container center fluid" id="page_content">
         <div id="pinkilo-card-container" class="container center row fluid">

--- a/site/src/js/components.js
+++ b/site/src/js/components.js
@@ -49,6 +49,8 @@ const Img = (src, alt) => {
   const i = E("img");
   i.setAttribute("src", src);
   i.setAttribute("alt", alt);
+  i.setAttribute("loading", "lazy");
+  i.setAttribute("decoding", "async");
   return i;
 };
 

--- a/site/src/style/components/badges.scss
+++ b/site/src/style/components/badges.scss
@@ -1,0 +1,18 @@
+@use "../variables/color" as *;
+@use "../variables/basic" as *;
+
+#badges {
+  padding: $padding 0;
+
+  .badge {
+    cursor: pointer;
+    margin: $margin;
+
+    border: 1px solid transparent;
+    transition: border-color 1s;
+
+    &:hover {
+      border-color: color(accent);
+    }
+  }
+}

--- a/site/src/style/components/header.scss
+++ b/site/src/style/components/header.scss
@@ -73,8 +73,9 @@ header.banner {
 
         border: 1px solid transparent;
         transform: translateY(-10%);
-        transition: all 1s;
+        transition: border-color 1s;
         animation: float 2s ease-in-out infinite;
+        will-change: transform;
 
         @for $i from 1 through 4 {
           &:nth-child(#{$i}) {
@@ -84,10 +85,6 @@ header.banner {
 
         &:hover {
           border-color: color(accent);
-          transform: translateY(-10%);
-          transition: all 1s;
-          animation: float 2s ease-in-out infinite;
-          animation-delay: 0.1s;
         }
       }
     }
@@ -106,6 +103,7 @@ header.banner {
 
       animation: float 2s ease-in-out infinite;
       transition: 0.5s;
+      will-change: transform;
 
       &:hover {
         border-color: color(accent);

--- a/site/src/style/components/header.scss
+++ b/site/src/style/components/header.scss
@@ -1,4 +1,3 @@
-@use "sass:math";
 @use "../variables/color" as *;
 @use "../variables/breakpoints" as *;
 @use "../variables/basic" as *;
@@ -44,48 +43,6 @@ header.banner {
 
       .tagline {
         font-size: 2em;
-      }
-    }
-
-    .container#badges {
-      max-width: 90%;
-      flex-direction: column;
-      justify-content: space-evenly;
-
-      place-content: unset;
-
-      @include phone-s() {
-        display: none;
-      }
-
-      @include tablet() {
-        flex-direction: row;
-        align-items: center;
-      }
-
-      .badge {
-        cursor: pointer;
-        margin: $margin 0 $margin auto;
-
-        @include tablet() {
-          margin: $margin auto;
-        }
-
-        border: 1px solid transparent;
-        transform: translateY(-10%);
-        transition: border-color 1s;
-        animation: float 2s ease-in-out infinite;
-        will-change: transform;
-
-        @for $i from 1 through 4 {
-          &:nth-child(#{$i}) {
-            animation-delay: math.random(30) + 10 + s;
-          }
-        }
-
-        &:hover {
-          border-color: color(accent);
-        }
       }
     }
 

--- a/site/src/style/index.scss
+++ b/site/src/style/index.scss
@@ -20,6 +20,7 @@
 // Components
 @use "./components/header.scss";
 @use "./components/navbar.scss";
+@use "./components/badges.scss";
 @use "./components/modal.scss";
 @use "./components/contact-form.scss";
 @use "./components/card.scss";


### PR DESCRIPTION
## Summary
The floating hero badges (GitHub/GitLab/LinkedIn/Resume) and the "My Projects" scroller button use a shared `float` CSS keyframe animation. Two separate issues were making that motion look jittery.

## Changes

### Fixes
#### Hero / header
- Removed the `.badge:hover` redeclaration of `animation` and `animation-delay`. Each badge's base rule assigns a random 11-40s `animation-delay` at compile time; hover was snapping that down to `0.1s`, which forces an instant jump in the running animation's keyframe position (`activeTime = localTime − delay`) instead of a smooth transition. Hover now only changes `border-color`.
- Scoped `.badge`'s `transition` from `all` to `border-color`, since that's the only property that changes on hover.
- Added `will-change: transform` to `.badge` and `button.scroller` so the browser can composite them on their own layer instead of repainting the large header background image behind them on every animation frame.
- Added explicit `width`/`height` attributes to the badge `<img>` tags so the layout box (and the percentage-based `translateY` in the `float` keyframe) is stable before the SVGs finish loading.

### Performance
#### Projects
- Project card thumbnails were being fetched and decoded eagerly on page load with no lazy loading, including a 6.99MB animated GIF and roughly 7MB of images total. That load/decode burst lands at the same moment the hero's float animation is on screen, competing for frame budget and reading as jitter in the hero rather than a CSS bug on its own. Added `loading="lazy"` and `decoding="async"` to project thumbnails so they only load as they approach the viewport.